### PR TITLE
Bump version from 2.2.3 to 2.2.4

### DIFF
--- a/BatRun.csproj
+++ b/BatRun.csproj
@@ -4,7 +4,7 @@
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
     <TargetFramework>net8.0-windows</TargetFramework>
-    <Version>2.2.3</Version>
+    <Version>2.2.4</Version>
     <Nullable>enable</Nullable>
     <UseWindowsForms>true</UseWindowsForms>
     <ImplicitUsings>enable</ImplicitUsings>


### PR DESCRIPTION
- Added a combined function with RetroBat.exe (starting with version 7.5.0.0.1) so that Batrun does not compete for focus
- Lock DPI scaling